### PR TITLE
change password strength requirements for Create User API

### DIFF
--- a/users/users.md
+++ b/users/users.md
@@ -184,14 +184,14 @@ The query parameters are not expected.
 
 #### Request body
 
-| Name | Type | Description | Required | Example |
-| ---- | ---- | ------------| :------: | ------- |
-| email | `string` | The new user’s email. | &#9745; | "email": "mona.benson<span>@sample.</span>com" |
-| firstName | `string` | The new user’s first name. | &#9745; | "firstName": "Mona" |
-| lastName | `string` | The new user’s last name. | &#9745; | "lastName": "Benson" |
-| password | `string` | The new user’s password. Password must be at least 10 characters long and should contain at least 1 digit and 1 character in UPPERCASE. | &#9745; | "password": "Samplepassword12" |
-| userRole | `enum` | The new user’s [role](./users_schemas.md/#user-roles). | &#9745; | "userRole": "Designer" |
-| timezone | `enum` | The new user’s [timezone](./users_schemas.md/#time-zone). | &#9745; | "timezone": "(UTC+10:00) Canberra, Melbourne, Sydney" |
+| Name | Type | Description                                                                                                                                                             | Required | Example |
+| ---- | ---- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------:| ------- |
+| email | `string` | The new user’s email.                                                                                                                                                   | &#9745;  | "email": "mona.benson<span>@sample.</span>com" |
+| firstName | `string` | The new user’s first name.                                                                                                                                              | &#9745;  | "firstName": "Mona" |
+| lastName | `string` | The new user’s last name.                                                                                                                                               | &#9745;  | "lastName": "Benson" |
+| password | `string` | The new user’s password. Password length must be between 12 and 64 characters. If the password is not supplied the user will receive an email to set up their password. | &#9744;  | "password": "Samplepassword12" |
+| userRole | `enum` | The new user’s [role](./users_schemas.md/#user-roles).                                                                                                                  | &#9745;  | "userRole": "Designer" |
+| timezone | `enum` | The new user’s [timezone](./users_schemas.md/#time-zone).                                                                                                               | &#9745;  | "timezone": "(UTC+10:00) Canberra, Melbourne, Sydney" |
 
 Example
 ```json


### PR DESCRIPTION
Updating the documentation to reflect the new requirements for password strength upon user creation. We also setting this as an optional field allowing users to create their own password once the account is created.